### PR TITLE
Add overlay gallery for flex items

### DIFF
--- a/css/effects.css
+++ b/css/effects.css
@@ -22,4 +22,27 @@
     100% {
       text-shadow: 2px 2px 0 #2943d1, -2px -2px 0 #f00;
     }
-  }
+}
+
+/* Overlay gallery styles */
+.image-overlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.8);
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.image-overlay.active {
+    display: flex;
+}
+
+.image-overlay-content img {
+    max-width: 90%;
+    max-height: 90%;
+}

--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
             <p class="mdtxt">gallery</p>
           </div>
     </div>
-    <div class="block-container flex-container">
+<div class="block-container flex-container">
         <img class="flex-item test-block" style="background-color: bisque;" src="img/img-placeholder.jpg">
         <img class="flex-item test-block" style="background-color: bisque;" src="img/img-placeholder.jpg">
         <img class="flex-item test-block" style="background-color: bisque;" src="img/img-placeholder.jpg">
@@ -186,14 +186,21 @@
 <!---------------------->
 </div>
 
+<!-- Overlay Gallery -->
+<div id="imageOverlay" class="image-overlay">
+  <div class="image-overlay-content">
+    <img id="overlayImg" src="" alt="">
+  </div>
+</div>
 
 <!---MY SCRIPTS--->
   <script src="js/stylescript.js"></script>
   <script src="js/text-slider.js"></script>
   <script src="js/img-slider.js"></script>
   <script src="js/waterFloat.js"></script>
+  <script src="js/gallery-overlay.js"></script>
 <!---END OF SCRIPTS--->
 
- </div>
+</div>
 </body>
 </html>

--- a/js/gallery-overlay.js
+++ b/js/gallery-overlay.js
@@ -1,0 +1,26 @@
+// Handles pop-up gallery overlay for flex-item images
+
+document.addEventListener('DOMContentLoaded', function () {
+    const overlay = document.getElementById('imageOverlay');
+    const overlayImg = document.getElementById('overlayImg');
+    const flexItems = document.querySelectorAll('.flex-item');
+
+    flexItems.forEach(function (item) {
+        if (item.tagName === 'IMG') {
+            item.addEventListener('click', function () {
+                const src = item.getAttribute('src');
+                if (src) {
+                    overlayImg.src = src;
+                }
+                overlay.classList.add('active');
+            });
+        }
+    });
+
+    overlay.addEventListener('click', function (e) {
+        if (e.target === overlay) {
+            overlay.classList.remove('active');
+            overlayImg.src = '';
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- show a centered overlay gallery when flex-item images are clicked
- fade background with opacity and close overlay when background is clicked

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68977caeb98c832c9f4add4a307876e5